### PR TITLE
Correctly resize output during extract

### DIFF
--- a/mlir_graphblas/implementations.py
+++ b/mlir_graphblas/implementations.py
@@ -24,7 +24,7 @@ from .tensor import SparseTensorBase, SparseTensor, Matrix, Vector, Scalar, Tran
 from .operators import UnaryOp, BinaryOp, SelectOp, IndexUnaryOp, Monoid, Semiring
 from .compiler import compile, engine_cache
 from . descriptor import Descriptor, NULL as NULL_DESC
-from .utils import get_sparse_output_pointer, get_scalar_output_pointer
+from .utils import get_sparse_output_pointer, get_scalar_output_pointer, renumber_indices
 from .types import RankedTensorType, BOOL, INT64, FP64
 
 
@@ -902,44 +902,58 @@ def _build_reduce_to_scalar(op: Monoid, sp: SparseTensorBase):
         return compile(module)
 
 
-def extract(tensor: SparseTensorBase, row_indices, col_indices=None):
+def extract(tensor: SparseTensorBase, row_indices, col_indices=None, row_size=None, col_size=None):
     # There may be a way to do this in MLIR, but for now we use numpy
     if tensor.ndims == 1:
         # Vector
         assert col_indices is None
-        if row_indices is None:  # None indicate GrB_ALL
+        assert col_size is None
+
+        if row_indices is None:  # None indicates GrB_ALL
             return tensor.dup()
+
         rowidx, vals = tensor.extract_tuples()
+        row_indices = np.array(row_indices)
         selected = np.isin(rowidx, row_indices)
-        v = Vector.new(tensor.dtype, *tensor.shape)
-        v.build(rowidx[selected], vals[selected])
+        # Filter and renumber rowidx
+        rowidx, vals = rowidx[selected], vals[selected]
+        rowidx = renumber_indices(rowidx, row_indices)
+        v = Vector.new(tensor.dtype, row_size)
+        v.build(rowidx, vals)
         return v
 
     # Matrix
     if row_indices is None and col_indices is None:
         return tensor.dup()
+
     rowidx, colidx, vals = tensor.extract_tuples()
     if row_indices is not None:
-        rowsel = np.isin(rowidx, row_indices)
-        # Apply rowsel filter
+        rindices_arr = np.array(row_indices)
+        rowsel = np.isin(rowidx, rindices_arr)
+        # Filter and renumber rowidx
         rowidx, colidx, vals = rowidx[rowsel], colidx[rowsel], vals[rowsel]
+        if type(row_indices) is not int:
+            rowidx = renumber_indices(rowidx, rindices_arr)
     if col_indices is not None:
-        colsel = np.isin(colidx, col_indices)
-        # Apply colsel filter
+        cindices_arr = np.array(col_indices)
+        colsel = np.isin(colidx, cindices_arr)
+        # Filter and renumber colidx
         rowidx, colidx, vals = rowidx[colsel], colidx[colsel], vals[colsel]
+        if type(col_indices) is not int:
+            colidx = renumber_indices(colidx, cindices_arr)
     if type(row_indices) is int:
         # Extract row as Vector
         assert np.all(rowidx == row_indices)
-        v = Vector.new(tensor.dtype, tensor.shape[1])
+        v = Vector.new(tensor.dtype, col_size)
         v.build(colidx, vals)
         return v
     if type(col_indices) is int:
         # Extract col as Vector
         assert np.all(colidx == col_indices)
-        v = Vector.new(tensor.dtype, tensor.shape[0])
+        v = Vector.new(tensor.dtype, row_size)
         v.build(rowidx, vals)
         return v
-    m = Matrix.new(tensor.dtype, *tensor.shape)
+    m = Matrix.new(tensor.dtype, row_size, col_size)
     m.build(rowidx, colidx, vals)
     return m
 

--- a/mlir_graphblas/tests/test_utils.py
+++ b/mlir_graphblas/tests/test_utils.py
@@ -1,0 +1,22 @@
+import pytest
+import numpy as np
+from mlir_graphblas import utils
+
+
+def test_renumber_indices():
+    a = np.array([1, 1, 1, 3, 5], dtype=np.uint64)
+    b = np.array([1, 2, 5, 3], dtype=np.uint64)
+    c = utils.renumber_indices(a, b)
+    assert c.dtype == np.uint64
+    np.testing.assert_equal(c, [0, 0, 0, 3, 2])
+
+    d = np.array([1, 2, 5, 47, 48, 49, 3], dtype=np.uint64)
+    e = utils.renumber_indices(a, d)
+    np.testing.assert_equal(e, [0, 0, 0, 6, 2])
+
+
+def test_renumber_indices_errors():
+    with pytest.raises(ValueError, match="4"):
+        utils.renumber_indices(np.array([1, 1, 1, 3, 5]), np.array([1, 4, 2, 5, 3, 4]))
+    with pytest.raises(KeyError, match="11"):
+        utils.renumber_indices(np.array([1, 2, 5, 11]), np.array([1, 2, 5, 3, 4]))


### PR DESCRIPTION
The previous code extracted the correct rows and columns from the input, but did not renumber the indices or adjust the output size. This code fixes those deficiencies and adds more tests to ensure full coverage of `extract`.