### PR TITLE
Assign operation

### DIFF
--- a/mlir_graphblas/implementations.py
+++ b/mlir_graphblas/implementations.py
@@ -165,6 +165,41 @@ def select_by_indices(sp: SparseTensorBase,
         sel = colsel
     m = Matrix.new(sp.dtype, *sp.shape)
     m.build(rowidx[sel], colidx[sel], vals[sel])
+    m._intermediate_result = True
+    return m
+
+
+def build_structural_vector_from_indices(size: int,
+                                         indices: Optional[list[int]] = None):
+    """
+    Returns a new sparse Vector of size `size` with dtype BOOL.
+    All elements in indices are set with a value of True.
+    """
+    v = Vector.new(BOOL, size)
+    if indices is None:
+        indices = np.arange(size)
+    v.build(indices, True)
+    return v
+
+
+def build_structural_matrix_from_indices(nrows: int,
+                                         ncols: int,
+                                         row_indices: Optional[list[int]] = None,
+                                         col_indices: Optional[list[int]] = None,
+                                         colwise=False):
+    """
+    Returns a new sparse Matrix of shape (nrows, ncols) with dtype BOOL.
+    All elements in (row_indices, col_indices) pairs are set with a value of True.
+    """
+    m = Matrix.new(BOOL, nrows, ncols)
+    if row_indices is None:
+        row_indices = np.arange(nrows)
+    if col_indices is None:
+        col_indices = np.arange(ncols)
+    # Build all combinations of indices
+    ridx = np.repeat(row_indices, len(col_indices))
+    cidx = np.tile(col_indices, len(row_indices))
+    m.build(ridx, cidx, True, colwise=colwise)
     return m
 
 

--- a/mlir_graphblas/implementations.py
+++ b/mlir_graphblas/implementations.py
@@ -26,7 +26,7 @@ from .compiler import compile, engine_cache
 from . descriptor import Descriptor, NULL as NULL_DESC
 from .utils import get_sparse_output_pointer, get_scalar_output_pointer, renumber_indices
 from .types import RankedTensorType, BOOL, INT64, FP64
-from .exceptions import GrbIndexOutOfBounds
+from .exceptions import GrbIndexOutOfBounds, GrbDimensionMismatch
 
 
 # TODO: vec->matrix broadcasting as builtin param in apply_mask (rowwise/colwise)
@@ -93,7 +93,7 @@ def _build_apply_mask(mask: SparseTensor, sp: SparseTensorBase, complement: bool
             @func.FuncOp.from_py_func(rtt_mask, rtt_sp)
             def main(msk, x):
                 c = [arith.ConstantOp(index, i) for i in range(rank)]
-                dims = [tensor.DimOp(x, c[i]).result for i in mask.permutation]
+                dims = [tensor.DimOp(msk, c[i]).result for i in mask.permutation]
                 out = bufferization.AllocTensorOp(rtt_out, dims, None, None, False)
                 generic_op = linalg.GenericOp(
                     [rtt_out],

--- a/mlir_graphblas/tensor.py
+++ b/mlir_graphblas/tensor.py
@@ -271,6 +271,7 @@ class Vector(SparseTensor):
 
         indices: list or numpy array of int
         values: list or numpy array with matching dtype as declared in `.new()`
+                can also be a scalar value to make the Vector iso-valued
         dup: BinaryOp used to combined entries with the same index
              NOTE: this is currently not support; passing dup will raise an error
         sparsity: list of string or DimLevelType
@@ -287,7 +288,10 @@ class Vector(SparseTensor):
         if not isinstance(indices, np.ndarray):
             indices = np.array(indices, dtype=np.uint64)
         if not isinstance(values, np.ndarray):
-            values = np.array(values, dtype=self.dtype.np_type)
+            if hasattr(values, '__len__'):
+                values = np.array(values, dtype=self.dtype.np_type)
+            else:
+                values = np.ones(indices.shape, dtype=self.dtype.np_type) * values
         if sparsity is None:
             sparsity = [DimLevelType.compressed]
         self._to_sparse_tensor(indices, values, sparsity=sparsity, ordering=[0])
@@ -363,6 +367,7 @@ class Matrix(SparseTensor):
         row_indices: list or numpy array of int
         col_indices: list or numpy array of int
         values: list or numpy array with matching dtype as declared in `.new()`
+                can also be a scalar value to make the Vector iso-valued
         dup: BinaryOp used to combined entries with the same (row, col) coordinate
              NOTE: this is currently not support; passing dup will raise an error
         sparsity: list of string or DimLevelType
@@ -383,7 +388,10 @@ class Matrix(SparseTensor):
             col_indices = np.array(col_indices, dtype=np.uint64)
         indices = np.stack([row_indices, col_indices], axis=1)
         if not isinstance(values, np.ndarray):
-            values = np.array(values, dtype=self.dtype.np_type)
+            if hasattr(values, '__len__'):
+                values = np.array(values, dtype=self.dtype.np_type)
+            else:
+                values = np.ones(indices.shape, dtype=self.dtype.np_type) * values
         ordering = [1, 0] if colwise else [0, 1]
         if sparsity is None:
             sparsity = [DimLevelType.dense, DimLevelType.compressed]

--- a/mlir_graphblas/tests/test_operations.py
+++ b/mlir_graphblas/tests/test_operations.py
@@ -2,12 +2,12 @@ import pytest
 import operator
 import functools
 import numpy as np
-from numpy.testing import assert_equal as np_assert_equal
 from numpy.testing import assert_allclose as np_assert_allclose
 from ..tensor import Scalar, Vector, Matrix
 from ..types import BOOL, INT16, INT32, INT64, FP32, FP64
 from .. import operations, descriptor as desc
 from ..operators import UnaryOp, BinaryOp, SelectOp, IndexUnaryOp, Monoid, Semiring
+from .utils import vector_compare, matrix_compare
 
 
 @pytest.fixture
@@ -44,67 +44,54 @@ def test_transpose_op(mm):
     operations.transpose(z, x)
     assert x.is_rowwise()
     assert z.is_colwise()
-    rowidx, colidx, vals = z.extract_tuples()
-    np_assert_equal(rowidx, xcols)
-    np_assert_equal(colidx, xrows)
-    np_assert_equal(vals, xvals)
+    matrix_compare(z, xcols, xrows, xvals)
 
     # Transpose of a transpose is no-op
     z = Matrix.new(x.dtype, *x.shape)
     operations.transpose(z, x, desc=desc.T0)
     assert x.is_rowwise()
-    rowidx, colidx, vals = z.extract_tuples()
-    np_assert_equal(rowidx, xrows)
-    np_assert_equal(colidx, xcols)
-    np_assert_equal(vals, xvals)
+    matrix_compare(z, xrows, xcols, xvals)
 
 
 def test_ewise_add_vec(vs):
     x, y = vs
     z = Vector.new(x.dtype, x.size())
     operations.ewise_add(z, BinaryOp.plus, x, y)
-    idx, vals = z.extract_tuples()
-    np_assert_equal(idx, [0, 1, 2, 3])
-    np_assert_allclose(vals, [1., 10., 22., 33.])
+    vector_compare(z, [0, 1, 2, 3], [1., 10., 22., 33.])
 
 
 def test_ewise_add_mat(ms):
     x, y = ms
     z = Matrix.new(x.dtype, *x.shape)
     operations.ewise_add(z, BinaryOp.times, x, y)
-    rowidx, colidx, vals = z.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 0, 1, 1, 1, 1])
-    np_assert_equal(colidx, [0, 1, 3, 0, 1, 3, 4])
-    np_assert_allclose(vals, [10, -20, -60, -3, -4, 40, -5])
+    matrix_compare(z,
+                   [0, 0, 0, 1, 1, 1, 1],
+                   [0, 1, 3, 0, 1, 3, 4],
+                   [10, -20, -60, -3, -4, 40, -5])
 
 
 def test_ewise_mult_vec(vs):
     x, y = vs
     z = Vector.new(x.dtype, x.size())
     operations.ewise_mult(z, BinaryOp.plus, x, y)
-    idx, vals = z.extract_tuples()
-    np_assert_equal(idx, [2, 3])
-    np_assert_allclose(vals, [22., 33.])
+    vector_compare(z, [2, 3], [22., 33.])
 
 
 def test_ewise_mult_mat(ms):
     x, y = ms
     z = Matrix.new(x.dtype, *x.shape)
     operations.ewise_mult(z, BinaryOp.first, x, y)
-    rowidx, colidx, vals = z.extract_tuples()
-    np_assert_equal(rowidx, [0, 0])
-    np_assert_equal(colidx, [1, 3])
-    np_assert_allclose(vals, [-1, -2])
+    matrix_compare(z, [0, 0], [1, 3], [-1, -2])
 
 
 def test_mxm(mm):
     x, y = mm
     z = Matrix.new(x.dtype, x.shape[0], y.shape[1])
     operations.mxm(z, Semiring.plus_times, x, y)
-    rowidx, colidx, vals = z.extract_tuples()
-    np_assert_equal(rowidx, [0, 1, 2, 2, 4])
-    np_assert_equal(colidx, [0, 0, 0, 4, 3])
-    np_assert_allclose(vals, [20.9, 16.5, 5.5, 70.4, 13.2])
+    matrix_compare(z,
+                   [0, 1, 2, 2, 4],
+                   [0, 0, 0, 4, 3],
+                   [20.9, 16.5, 5.5, 70.4, 13.2])
 
 
 def test_mxv(vs, mm):
@@ -112,14 +99,11 @@ def test_mxv(vs, mm):
     _, m = mm
     z = Vector.new(m.dtype, m.shape[0])
     operations.mxv(z, Semiring.plus_times, m, v)
-    idx, vals = z.extract_tuples()
     try:
-        np_assert_equal(idx, [1, 2, 3, 5])
-        np_assert_allclose(vals, [1., 6., 5., 7.])
+        vector_compare(z, [1, 2, 3, 5], [1., 6., 5., 7.])
     except AssertionError:
         # Check for dense return, indicating lack of lex insert fix
-        np_assert_equal(idx, [0, 1, 2, 3, 4, 5])
-        np_assert_allclose(vals, [0., 1., 6., 5., 0., 7.])
+        vector_compare(z, [0, 1, 2, 3, 4, 5], [0., 1., 6., 5., 0., 7.])
         pytest.xfail("Waiting for lex insert fix")
 
 
@@ -128,9 +112,7 @@ def test_vxm(vs, mm):
     m, _ = mm
     z = Vector.new(m.dtype, m.shape[1])
     operations.vxm(z, Semiring.plus_times, v, m)
-    idx, vals = z.extract_tuples()
-    np_assert_equal(idx, [0, 1, 3, 5])
-    np_assert_allclose(vals, [8.8, 11., 1.1, 2.2])
+    vector_compare(z, [0, 1, 3, 5], [8.8, 11., 1.1, 2.2])
 
 
 def test_apply_mat(ms):
@@ -140,34 +122,22 @@ def test_apply_mat(ms):
     # UnaryOp.abs
     z = Matrix.new(x.dtype, *x.shape)
     operations.apply(z, UnaryOp.abs, x)
-    zrows, zcols, zvals = z.extract_tuples()
-    np_assert_equal(zrows, xrows)
-    np_assert_equal(zcols, xcols)
-    np_assert_allclose(zvals, np.abs(xvals))
+    matrix_compare(z, xrows, xcols, np.abs(xvals))
 
     # BinaryOp.minus left=2
     z2 = Matrix.new(x.dtype, *x.shape)
     operations.apply(z2, BinaryOp.minus, x, left=2)
-    z2rows, z2cols, z2vals = z2.extract_tuples()
-    np_assert_equal(z2rows, xrows)
-    np_assert_equal(z2cols, xcols)
-    np_assert_allclose(z2vals, 2 - xvals)
+    matrix_compare(z2, xrows, xcols, 2 - xvals)
 
     # BinaryOp.gt right=-2
     z3 = Matrix.new(BOOL, *x.shape)
     operations.apply(z3, BinaryOp.ge, x, right=-2)
-    z3rows, z3cols, z3vals = z3.extract_tuples()
-    np_assert_equal(z3rows, xrows)
-    np_assert_equal(z3cols, xcols)
-    np_assert_allclose(z3vals, xvals >= -2)
+    matrix_compare(z3, xrows, xcols, xvals >= -2)
 
     # IndexUnaryOp.rowindex thunk=1
     z4 = Matrix.new(INT64, *x.shape)
     operations.apply(z4, IndexUnaryOp.rowindex, x, thunk=1)
-    z4rows, z4cols, z4vals = z4.extract_tuples()
-    np_assert_equal(z4rows, xrows)
-    np_assert_equal(z4cols, xcols)
-    np_assert_allclose(z4vals, xrows + 1)
+    matrix_compare(z4, xrows, xcols, xrows + 1)
 
 
 def test_apply_indexunary_transposed(ms):
@@ -177,27 +147,22 @@ def test_apply_indexunary_transposed(ms):
     # IndexUnaryOp.rowindex thunk=1
     z = Matrix.new(INT64, x.shape[1], x.shape[0])
     operations.apply(z, IndexUnaryOp.rowindex, x, thunk=1, desc=desc.T0)
-    zrows, zcols, zvals = z.extract_tuples()
-    np_assert_equal(zrows, xcols)
-    np_assert_equal(zcols, xrows)
-    np_assert_allclose(zvals, xcols + 1)
+    matrix_compare(z, xcols, xrows, xcols + 1)
 
 
 def test_apply_inplace():
     v = Vector.new(INT32, 6)
     v.build([0, 3, 4], [15, 16, 17])
     operations.apply(v, BinaryOp.times, v, right=3)
-    idx, vals = v.extract_tuples()
-    np_assert_equal(idx, [0, 3, 4])
-    np_assert_equal(vals, [45, 48, 51])
+    vector_compare(v, [0, 3, 4], [45, 48, 51])
 
     m = Matrix.new(FP64, 2, 5)
     m.build([0, 0, 1, 1, 1], [1, 3, 0, 2, 3], [2., 50., 25., 20., 15.])
     operations.apply(m, UnaryOp.minv, m)
-    rows, cols, vals = m.extract_tuples()
-    np_assert_equal(rows, [0, 0, 1, 1, 1])
-    np_assert_equal(cols, [1, 3, 0, 2, 3])
-    np_assert_allclose(vals, [.5, .02, .04, .05, .06666666666667])
+    matrix_compare(m,
+                   [0, 0, 1, 1, 1],
+                   [1, 3, 0, 2, 3],
+                   [.5, .02, .04, .05, .06666666666667])
 
 
 def test_select_vec(vs):
@@ -206,16 +171,12 @@ def test_select_vec(vs):
     # Select by index
     z = Vector.new(x.dtype, x.size())
     operations.select(z, SelectOp.rowgt, x, 2)
-    idx, vals = z.extract_tuples()
-    np_assert_equal(idx, [3])
-    np_assert_allclose(vals, [30.])
+    vector_compare(z, [3], [30.])
 
     # Select by value
     z = Vector.new(x.dtype, x.size())
     operations.select(z, SelectOp.valuegt, x, 10.)
-    idx, vals = z.extract_tuples()
-    np_assert_equal(idx, [2, 3])
-    np_assert_allclose(vals, [20., 30.])
+    vector_compare(z, [2, 3], [20., 30.])
 
 
 def test_select_mat(mm):
@@ -223,19 +184,13 @@ def test_select_mat(mm):
     z = Matrix.new(y.dtype, *y.shape)
     operations.select(z, SelectOp.triu, y, -1)
     assert z.is_rowwise()
-    rowidx, colidx, vals = z.extract_tuples()
-    np_assert_equal(rowidx, [0, 1, 1, 2])
-    np_assert_equal(colidx, [4, 0, 4, 3])
-    np_assert_allclose(vals, [6., 1., 8., 2.])
+    matrix_compare(z, [0, 1, 1, 2], [4, 0, 4, 3], [6., 1., 8., 2.])
 
     # Transposed
     z = Matrix.new(y.dtype, y.shape[1], y.shape[0])
     operations.select(z, SelectOp.triu, y, 0, desc=desc.T0)
     assert z.is_colwise()
-    rowidx, colidx, vals = z.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 0])
-    np_assert_equal(colidx, [1, 3, 5])
-    np_assert_allclose(vals, [1., 5., 7.])
+    matrix_compare(z, [0, 0, 0], [1, 3, 5], [1., 5., 7.])
 
 
 def test_empty_select():
@@ -249,14 +204,11 @@ def test_reduce_rowwise(mm):
     x, _ = mm
     z = Vector.new(x.dtype, x.shape[0])
     operations.reduce_to_vector(z, Monoid.plus, x)
-    idx, vals = z.extract_tuples()
     try:
-        np_assert_equal(idx, [0, 1, 2, 4])
-        np_assert_allclose(vals, [3.3, 3.3, 9.9, 6.6])
+        vector_compare(z, [0, 1, 2, 4], [3.3, 3.3, 9.9, 6.6])
     except AssertionError:
         # Check for dense return, indicating lack of lex insert fix
-        np_assert_equal(idx, [0, 1, 2, 3, 4])
-        np_assert_allclose(vals, [3.3, 3.3, 9.9, 0.0, 6.6])
+        vector_compare(z, [0, 1, 2, 3, 4], [3.3, 3.3, 9.9, 0.0, 6.6])
         pytest.xfail("Waiting for lex insert fix")
 
 
@@ -264,9 +216,7 @@ def test_reduce_colwise(mm):
     x, _ = mm
     z = Vector.new(x.dtype, x.shape[1])
     operations.reduce_to_vector(z, Monoid.times, x, desc=desc.T0)
-    idx, vals = z.extract_tuples()
-    np_assert_equal(idx, [0, 1, 2, 3, 5])
-    np_assert_allclose(vals, [4.4, 5.5, 6.6, 3.63, 2.2])
+    vector_compare(z, [0, 1, 2, 3, 5], [4.4, 5.5, 6.6, 3.63, 2.2])
 
 
 def test_reduce_scalar_mat(mm):
@@ -294,16 +244,12 @@ def test_extract_vec(vs):
     xidx, xvals = x.extract_tuples()
     z = Vector.new(x.dtype, 3)
     operations.extract(z, x, [0, 1, 3])
-    idx, vals = z.extract_tuples()
-    np_assert_equal(idx, [1, 2])
-    np_assert_allclose(vals, [10., 30.])
+    vector_compare(z, [1, 2], [10., 30.])
 
     # Extract all
     z2 = Vector.new(x.dtype, *x.shape)
     operations.extract(z2, x, None)
-    idx, vals = z2.extract_tuples()
-    np_assert_equal(idx, xidx)
-    np_assert_allclose(vals, xvals)
+    vector_compare(z2, xidx, xvals)
 
 
 def test_extract_mat(mm):
@@ -313,34 +259,25 @@ def test_extract_mat(mm):
     # Extract all rows, all cols
     z = Matrix.new(x.dtype, *x.shape)
     operations.extract(z, x, None, None)
-    rowidx, colidx, vals = z.extract_tuples()
-    np_assert_equal(rowidx, xrows)
-    np_assert_equal(colidx, xcols)
-    np_assert_allclose(vals, xvals)
+    matrix_compare(z, xrows, xcols, xvals)
 
     # Extract some rows, some cols
     z2 = Matrix.new(x.dtype, 2, 4)
     operations.extract(z2, x, [0, 4], [1, 2, 3, 5])
-    rowidx, colidx, vals = z2.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 1])
-    np_assert_equal(colidx, [2, 3, 1])
-    np_assert_allclose(vals, [1.1, 2.2, 6.6])
+    matrix_compare(z2, [0, 0, 1], [2, 3, 1], [1.1, 2.2, 6.6])
 
     # Extract some rows, all cols
     z3 = Matrix.new(x.dtype, 2, x.shape[1])
     operations.extract(z3, x, [0, 4], None)
-    rowidx, colidx, vals = z3.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 1])
-    np_assert_equal(colidx, [3, 5, 2])
-    np_assert_allclose(vals, [1.1, 2.2, 6.6])
+    matrix_compare(z3, [0, 0, 1], [3, 5, 2], [1.1, 2.2, 6.6])
 
     # Extract all rows, some cols
     z4 = Matrix.new(x.dtype, x.shape[0], 4)
     operations.extract(z4, x, None, [1, 5, 3, 2])
-    rowidx, colidx, vals = z4.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 1, 2, 4])
-    np_assert_equal(colidx, [1, 2, 2, 0, 3])
-    np_assert_allclose(vals, [2.2, 1.1, 3.3, 5.5, 6.6])
+    matrix_compare(z4,
+                   [0, 0, 1, 2, 4],
+                   [1, 2, 2, 0, 3],
+                   [2.2, 1.1, 3.3, 5.5, 6.6])
 
 
 def test_extract_vec_from_mat(mm):
@@ -348,37 +285,27 @@ def test_extract_vec_from_mat(mm):
     # Extract partial column
     z = Vector.new(x.dtype, 3)
     operations.extract(z, x, [0, 1, 4], 2)
-    idx, vals = z.extract_tuples()
-    np_assert_equal(idx, [2])
-    np_assert_allclose(vals, [6.6])
+    vector_compare(z, [2], [6.6])
 
     # Extract full column
     z1 = Vector.new(x.dtype, x.shape[0])
     operations.extract(z1, x, None, 3)
-    idx, vals = z1.extract_tuples()
-    np_assert_equal(idx, [0, 1])
-    np_assert_allclose(vals, [1.1, 3.3])
+    vector_compare(z1, [0, 1], [1.1, 3.3])
 
     # Extract partial row
     z2 = Vector.new(x.dtype, 5)
     operations.extract(z2, x, 0, [0, 1, 3, 4, 5])
-    idx, vals = z2.extract_tuples()
-    np_assert_equal(idx, [2, 4])
-    np_assert_allclose(vals, [1.1, 2.2])
+    vector_compare(z2, [2, 4], [1.1, 2.2])
 
     # Extract full row
     z3 = Vector.new(x.dtype, x.shape[1])
     operations.extract(z3, x, 0, None)
-    idx, vals = z3.extract_tuples()
-    np_assert_equal(idx, [3, 5])
-    np_assert_allclose(vals, [1.1, 2.2])
+    vector_compare(z3, [3, 5], [1.1, 2.2])
 
     # Extract partial column via transposed input
     z3 = Vector.new(x.dtype, 3)
     operations.extract(z3, x, 2, [0, 1, 4], desc=desc.T0)
-    idx, vals = z3.extract_tuples()
-    np_assert_equal(idx, [2])
-    np_assert_allclose(vals, [6.6])
+    vector_compare(z3, [2], [6.6])
 
 
 def test_assign_vec(vs):
@@ -386,17 +313,13 @@ def test_assign_vec(vs):
 
     # Assign all
     operations.assign(y, x, accum=BinaryOp.plus)
-    idx, vals = y.extract_tuples()
-    np_assert_equal(idx, [0, 1, 2, 3])
-    np_assert_allclose(vals, [1., 10., 22., 33.])
+    vector_compare(y, [0, 1, 2, 3], [1., 10., 22., 33.])
 
     # Expand
     z = Vector.new(x.dtype, 16)
     operations.assign(z, x, [1, 3, 13, 10, 2])
-    idx, vals = z.extract_tuples()
     assert z.size() == 16
-    np_assert_equal(idx, [3, 10, 13])
-    np_assert_allclose(vals, [10., 30., 20.])
+    vector_compare(z, [3, 10, 13], [10., 30., 20.])
 
 
 def test_assign_mat(ms):
@@ -405,34 +328,34 @@ def test_assign_mat(ms):
     # Assign identical rows, identical cols
     z = y.dup()
     operations.assign(z, x, accum=BinaryOp.plus)
-    rowidx, colidx, vals = z.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 0, 1, 1, 1, 1])
-    np_assert_equal(colidx, [0, 1, 3, 0, 1, 3, 4])
-    np_assert_allclose(vals, [10, 19, 28, -3, -4, 40, -5])
+    matrix_compare(z,
+                   [0, 0, 0, 1, 1, 1, 1],
+                   [0, 1, 3, 0, 1, 3, 4],
+                   [10, 19, 28, -3, -4, 40, -5])
 
     # Assign new rows, new cols
     z2 = Matrix.new(x.dtype, 4, 8)
     operations.assign(z2, x, [3, 0], [0, 3, 4, 1, 7])
-    rowidx, colidx, vals = z2.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 0, 3, 3])
-    np_assert_equal(colidx, [0, 3, 7, 1, 3])
-    np_assert_allclose(vals, [-3, -4, -5, -2, -1])
+    matrix_compare(z2,
+                   [0, 0, 0, 3, 3],
+                   [0, 3, 7, 1, 3],
+                   [-3, -4, -5, -2, -1])
 
     # Assign identical rows, new cols
     z3 = Matrix.new(x.dtype, x.shape[0], 8)
     operations.assign(z3, x, None, [0, 3, 4, 1, 7])
-    rowidx, colidx, vals = z3.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 1, 1, 1])
-    np_assert_equal(colidx, [1, 3, 0, 3, 7])
-    np_assert_allclose(vals, [-2, -1, -3, -4, -5])
+    matrix_compare(z3,
+                   [0, 0, 1, 1, 1],
+                   [1, 3, 0, 3, 7],
+                   [-2, -1, -3, -4, -5])
 
     # Assign new rows, identical cols
     z4 = Matrix.new(x.dtype, 4, x.shape[1])
     operations.assign(z4, x, [3, 0], None)
-    rowidx, colidx, vals = z4.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 0, 3, 3])
-    np_assert_equal(colidx, [0, 1, 4, 1, 3])
-    np_assert_allclose(vals, [-3, -4, -5, -1, -2])
+    matrix_compare(z4,
+                   [0, 0, 0, 3, 3],
+                   [0, 1, 4, 1, 3],
+                   [-3, -4, -5, -1, -2])
 
 
 def test_assign_vec_to_mat(ms):
@@ -443,40 +366,40 @@ def test_assign_vec_to_mat(ms):
     r0 = Vector.new(x.dtype, x.shape[1])
     r0.build([0, 2, 3, 4], [5, 4, 3, 2])
     operations.assign(z1, r0, 0, None, accum=BinaryOp.plus)
-    rowidx, colidx, vals = z1.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 0, 0, 0, 1, 1, 1])
-    np_assert_equal(colidx, [0, 1, 2, 3, 4, 0, 1, 4])
-    np_assert_allclose(vals, [5, -1, 4, 1, 2, -3, -4, -5])
+    matrix_compare(z1,
+                   [0, 0, 0, 0, 0, 1, 1, 1],
+                   [0, 1, 2, 3, 4, 0, 1, 4],
+                   [5, -1, 4, 1, 2, -3, -4, -5])
 
     # Assign row with new indices
     z2 = x.dup()
     r1 = Vector.new(x.dtype, 3)
     r1.build([0, 2], [100, 150])
     operations.assign(z2, r1, 0, [4, 0, 2], accum=BinaryOp.plus)
-    rowidx, colidx, vals = z2.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 0, 0, 1, 1, 1])
-    np_assert_equal(colidx, [1, 2, 3, 4, 0, 1, 4])
-    np_assert_allclose(vals, [-1, 150, -2, 100, -3, -4, -5])
+    matrix_compare(z2,
+                   [0, 0, 0, 0, 1, 1, 1],
+                   [1, 2, 3, 4, 0, 1, 4],
+                   [-1, 150, -2, 100, -3, -4, -5])
 
     # Assign col with identical indices
     z3 = x.dup()
     c0 = Vector.new(x.dtype, x.shape[0])
     c0.build([0, 1], [97, 99])
     operations.assign(z3, c0, None, 3, accum=BinaryOp.plus)
-    rowidx, colidx, vals = z3.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 1, 1, 1, 1])
-    np_assert_equal(colidx, [1, 3, 0, 1, 3, 4])
-    np_assert_allclose(vals, [-1, 95, -3, -4, 99, -5])
+    matrix_compare(z3,
+                   [0, 0, 1, 1, 1, 1],
+                   [1, 3, 0, 1, 3, 4],
+                   [-1, 95, -3, -4, 99, -5])
 
     # Assign col with new indices
     z4 = x.dup()
     c1 = Vector.new(x.dtype, 1)
     c1.build([0], [101])
     operations.assign(z4, c1, [1], 3, accum=BinaryOp.plus)
-    rowidx, colidx, vals = z4.extract_tuples()
-    np_assert_equal(rowidx, [0, 0, 1, 1, 1, 1])
-    np_assert_equal(colidx, [1, 3, 0, 1, 3, 4])
-    np_assert_allclose(vals, [-1, -2, -3, -4, 101, -5])
+    matrix_compare(z4,
+                   [0, 0, 1, 1, 1, 1],
+                   [1, 3, 0, 1, 3, 4],
+                   [-1, -2, -3, -4, 101, -5])
 
 
 # TODO: test assign with scalar input

--- a/mlir_graphblas/tests/test_select_utils.py
+++ b/mlir_graphblas/tests/test_select_utils.py
@@ -1,0 +1,40 @@
+import pytest
+from mlir_graphblas.implementations import select_by_mask, select_by_indices
+from ..tensor import Scalar, Vector, Matrix
+from ..types import BOOL, INT16, INT32, INT64, FP32, FP64
+from .. import operations, descriptor as desc
+from ..operators import UnaryOp, BinaryOp, SelectOp, IndexUnaryOp, Monoid, Semiring
+from .utils import vector_compare, matrix_compare
+
+
+def test_select_by_indices_vec():
+    v = Vector.new(INT16, 10)
+    v.build([0, 2, 3, 4, 5, 8, 9], [1, 2, 3, 4, 5, 6, 7])
+    w1 = select_by_indices(v, [0, 1, 2, 3, 4, 9, 10])
+    vector_compare(w1, [0, 2, 3, 4, 9], [1, 2, 3, 4, 7])
+    w2 = select_by_indices(v, [0, 1, 2, 3, 4, 9, 10], complement=True)
+    vector_compare(w2, [5, 8], [5, 6])
+    w3 = select_by_indices(v, None)
+    vector_compare(w3, [0, 2, 3, 4, 5, 8, 9], [1, 2, 3, 4, 5, 6, 7])
+    w4 = select_by_indices(v, None, complement=True)
+    assert w4._obj is None
+
+    with pytest.raises(AssertionError):
+        select_by_indices(v, [0, 1, 2], [2, 3, 4])
+
+
+def test_select_by_indices_mat():
+    m = Matrix.new(INT32, 3, 5)
+    m.build([0, 0, 0, 2, 2, 2], [1, 2, 4, 0, 2, 4], [1, 2, 3, 4, 5, 6])
+    z1 = select_by_indices(m, [1, 0], [0, 2, 3, 4])
+    matrix_compare(z1, [0, 0], [2, 4], [2, 3])
+    z2 = select_by_indices(m, [0, 1], [0, 2, 3, 4], complement=True)
+    matrix_compare(z2, [0, 2, 2, 2], [1, 0, 2, 4], [1, 4, 5, 6])
+    z3 = select_by_indices(m, None, [0, 2, 4])
+    matrix_compare(z3, [0, 0, 2, 2, 2], [2, 4, 0, 2, 4], [2, 3, 4, 5, 6])
+    z4 = select_by_indices(m, [0, 1], None)
+    matrix_compare(z4, [0, 0, 0], [1, 2, 4], [1, 2, 3])
+    z5 = select_by_indices(m, None, [0, 2, 4], complement=True)
+    matrix_compare(z5, [0], [1], [1])
+    z6 = select_by_indices(m, [0, 1], None, complement=True)
+    matrix_compare(z6, [2, 2, 2], [0, 2, 4], [4, 5, 6])

--- a/mlir_graphblas/tests/test_update.py
+++ b/mlir_graphblas/tests/test_update.py
@@ -148,3 +148,6 @@ def test_value_mask(mats):
     np_assert_equal(rows, [0, 0, 1, 1, 1, 1])
     np_assert_equal(cols, [0, 1, 0, 1, 3, 4])
     np_assert_allclose(vals, [9, 200, 300, -4, 40, -5])
+
+
+# TODO: verify all output arguments with assign

--- a/mlir_graphblas/tests/test_update.py
+++ b/mlir_graphblas/tests/test_update.py
@@ -266,7 +266,7 @@ def test_assign_mask(assign_mats):
     matrix_compare(x, [0, 0, 0, 1, 1, 2, 2], [0, 1, 2, 1, 2, 0, 1], [1, 2, 13, 5, 6, 11, 8])
 
 
-def test_assign_mask_complement_zz(assign_mats):
+def test_assign_mask_complement(assign_mats):
     x, y, mask = assign_mats
     x1 = x.dup()
     operations.assign(x1, y, [0, 2], [0, 2], mask=mask, desc=descriptor.SC)

--- a/mlir_graphblas/tests/utils.py
+++ b/mlir_graphblas/tests/utils.py
@@ -1,0 +1,22 @@
+import numpy as np
+from numpy.testing import assert_equal as np_assert_equal
+from numpy.testing import assert_allclose as np_assert_allclose
+
+
+def vector_compare(vec, i, v):
+    assert vec.ndims == 1
+    idx, vals = vec.extract_tuples()
+    np_assert_equal(idx, i)
+    np_assert_allclose(vals, v)
+
+
+def matrix_compare(mat, r, c, v):
+    assert mat.ndims == 2
+    rows, cols, vals = mat.extract_tuples()
+    if mat.is_rowwise():
+        sort_order = np.argsort(r)
+    else:
+        sort_order = np.argsort(c)
+    np_assert_equal(rows, np.array(r)[sort_order])
+    np_assert_equal(cols, np.array(c)[sort_order])
+    np_assert_allclose(vals, np.array(v)[sort_order])

--- a/mlir_graphblas/utils.py
+++ b/mlir_graphblas/utils.py
@@ -39,6 +39,14 @@ def ensure_scalar_of_type(obj, dtype):
     return s
 
 
+def ensure_unique(indices, name=None):
+    unique = np.unique(indices)
+    if len(unique) < len(indices):
+        unique, counts = np.unique(indices, return_counts=True)
+        name_str = f" in {name}" if name is not None else ""
+        raise ValueError(f"Found duplicate indices{name_str}: {unique[counts > 1]}")
+
+
 def renumber_indices(indices, selected):
     """
     Given a set of non-unique `indices`, returns an array of the same size
@@ -63,6 +71,7 @@ def renumber_indices(indices, selected):
     array([0, 0, 0, 3, 2])
     """
     # Check that values in selected are unique
+    # TODO: fix this; extract must allow non-unique selected indices
     unique = np.unique(selected)
     if unique.size < selected.size:
         unique, counts = np.unique(selected, return_counts=True)


### PR DESCRIPTION
This implements all of the `assign` operations:

- assign vec to vec
- assign mat to mat
- assign vec to mat as row
- assign vec to mat as col
- assign scalar to vec
- assign scalar to mat

The `update` function had to be improved to handle `assign` which essentially needs to treat assignment indices as a 2nd mask. Having two masks, combined with mask complement and replacement logic gets very tricky.

Three new implementations (beyond `assign`) are needed:

- select_by_indices
- build_iso_vector_from_indices
- build_iso_matrix_from_indices